### PR TITLE
fix(#57): don't merge stderr with stdout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 node_modules/
 target/
 .claude/
+.aidy/

--- a/src/main/java/com/yegor256/Jaxec.java
+++ b/src/main/java/com/yegor256/Jaxec.java
@@ -119,10 +119,7 @@ public final class Jaxec {
      */
     public Jaxec(final Collection<String> args, final File dir,
         final boolean chk, final InputStream input) {
-        this(
-            new ProcessBuilder().directory(dir).redirectErrorStream(true),
-            args, chk, input
-        );
+        this(new ProcessBuilder().directory(dir), args, chk, input);
     }
 
     /**

--- a/src/test/java/com/yegor256/JaxecTest.java
+++ b/src/test/java/com/yegor256/JaxecTest.java
@@ -159,7 +159,7 @@ final class JaxecTest {
             new Jaxec("cat", "/file-is-definitely-absent")
                 .withCheck(false)
                 .exec()
-                .stdout(),
+                .stderr(),
             Matchers.containsString("No such file or directory")
         );
     }


### PR DESCRIPTION
This PR modifies `Jaxec` to properly handle stderr output, making it separate from stdout.

Closes #57