### PR TITLE
Upgrade dependencies and plugins to latest stable versions

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, macos-15, windows-2022]
-        java: [17, 21]
+        java: [21]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-java@v5

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>parent</artifactId>
-    <version>0.69.6</version>
+    <version>0.73.1</version>
   </parent>
   <groupId>com.yegor256</groupId>
   <artifactId>jaxec</artifactId>
@@ -86,31 +86,31 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.13.4</version>
+      <version>6.0.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.13.4</version>
+      <version>6.0.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <version>5.13.4</version>
+      <version>6.0.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-engine</artifactId>
-      <version>1.13.4</version>
+      <version>6.0.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-commons</artifactId>
-      <version>1.13.4</version>
+      <version>6.0.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -144,7 +144,7 @@
       <plugin>
         <groupId>org.pitest</groupId>
         <artifactId>pitest-maven</artifactId>
-        <version>1.20.3</version>
+        <version>1.23.1</version>
         <executions>
           <execution>
             <goals>
@@ -174,7 +174,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.24.2</version>
+            <version>0.27.5</version>
             <configuration>
               <excludes combine.children="append">
                 <exclude>checkstyle:/src/site/resources/.*</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -141,32 +141,45 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.pitest</groupId>
-        <artifactId>pitest-maven</artifactId>
-        <version>1.23.1</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>mutationCoverage</goal>
-            </goals>
-            <configuration>
-              <threads>4</threads>
-              <mutationThreshold>65</mutationThreshold>
-            </configuration>
-          </execution>
-        </executions>
-        <dependencies>
-          <dependency>
-            <groupId>org.pitest</groupId>
-            <artifactId>pitest-junit5-plugin</artifactId>
-            <version>1.2.3</version>
-          </dependency>
-        </dependencies>
-      </plugin>
     </plugins>
   </build>
   <profiles>
+    <profile>
+      <id>pit</id>
+      <activation>
+        <os>
+          <family>unix</family>
+        </os>
+        <jdk>[11,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.pitest</groupId>
+            <artifactId>pitest-maven</artifactId>
+            <version>1.23.1</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>mutationCoverage</goal>
+                </goals>
+                <configuration>
+                  <threads>4</threads>
+                  <mutationThreshold>65</mutationThreshold>
+                </configuration>
+              </execution>
+            </executions>
+            <dependencies>
+              <dependency>
+                <groupId>org.pitest</groupId>
+                <artifactId>pitest-junit5-plugin</artifactId>
+                <version>1.2.3</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>qulice</id>
       <build>

--- a/src/main/java/com/yegor256/Jaxec.java
+++ b/src/main/java/com/yegor256/Jaxec.java
@@ -60,7 +60,7 @@ import java.util.logging.Level;
  *
  * @since 0.0.1
  */
-@SuppressWarnings({ "PMD.TooManyMethods", "PMD.GodClass" })
+@SuppressWarnings("PMD.TooManyMethods")
 public final class Jaxec {
 
     /**
@@ -92,6 +92,7 @@ public final class Jaxec {
     /**
      * Constructs a new Jaxec with the given command line arguments.
      * @param args The command line arguments (first element is the command, rest are parameters)
+     * @checkstyle ConstructorsCodeFreeCheck (3 lines)
      */
     public Jaxec(final String... args) {
         this(Arrays.asList(args));
@@ -101,6 +102,7 @@ public final class Jaxec {
      * Constructs a new Jaxec with the given command line arguments.
      * Uses the current working directory as the home directory.
      * @param args The command line arguments as a collection
+     * @checkstyle ConstructorsCodeFreeCheck (3 lines)
      */
     public Jaxec(final Collection<String> args) {
         this(args, new File(System.getProperty("user.dir")));
@@ -111,6 +113,7 @@ public final class Jaxec {
      * Exit code checking is enabled by default.
      * @param args The command line arguments
      * @param dir Home directory where the command will be executed
+     * @checkstyle ConstructorsCodeFreeCheck (3 lines)
      */
     public Jaxec(final Collection<String> args, final File dir) {
         this(args, dir, true, new ByteArrayInputStream(new byte[] {}));
@@ -123,6 +126,7 @@ public final class Jaxec {
      * @param chk Check exit code and fail if it's not zero
      * @param input Input stream to be used as STDIN for the process
      * @checkstyle ParameterNumberCheck (5 lines)
+     * @checkstyle ConstructorsCodeFreeCheck (5 lines)
      */
     public Jaxec(final Collection<String> args, final File dir,
         final boolean chk, final InputStream input) {
@@ -137,6 +141,7 @@ public final class Jaxec {
      * @param input Input stream to be used as STDIN for the process
      * @since 0.3.0
      * @checkstyle ParameterNumberCheck (5 lines)
+     * @checkstyle ConstructorsCodeFreeCheck (5 lines)
      */
     public Jaxec(final ProcessBuilder pcs, final Collection<String> args,
         final boolean chk, final InputStream input) {
@@ -152,6 +157,7 @@ public final class Jaxec {
      * @param env Environment variables to set for the process
      * @since 0.5.0
      * @checkstyle ParameterNumberCheck (5 lines)
+     * @checkstyle ConstructorsCodeFreeCheck (10 lines)
      */
     public Jaxec(final ProcessBuilder pcs, final Collection<String> args,
         final boolean chk, final InputStream input, final Map<String, String> env) {
@@ -418,5 +424,4 @@ public final class Jaxec {
             }
         };
     }
-
 }

--- a/src/main/java/com/yegor256/Result.java
+++ b/src/main/java/com/yegor256/Result.java
@@ -12,19 +12,19 @@ public interface Result {
 
     /**
      * Exit code.
-     * @return Exit code.
+     * @return Exit code
      */
     int code();
 
     /**
      * Stdout.
-     * @return Stdout.
+     * @return Stdout
      */
     String stdout();
 
     /**
      * Stderr.
-     * @return Stderr.
+     * @return Stderr
      */
     String stderr();
 }

--- a/src/test/java/com/yegor256/JaxecTest.java
+++ b/src/test/java/com/yegor256/JaxecTest.java
@@ -25,10 +25,14 @@ import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test case for {@link Jaxec}.
- *
  * @since 0.1.0
  */
-@SuppressWarnings({ "PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals" })
+@SuppressWarnings({
+    "PMD.TooManyMethods",
+    "PMD.AvoidDuplicateLiterals",
+    "PMD.UnitTestContainsTooManyAsserts",
+    "PMD.UnnecessaryLocalRule"
+})
 final class JaxecTest {
 
     @Test
@@ -108,8 +112,10 @@ final class JaxecTest {
     @Test
     @EnabledOnOs(OS.WINDOWS)
     void listDirectoryInWindows(@TempDir final Path temp) throws IOException {
-        final Path file = temp.resolve("test.txt");
-        Files.write(file, "Hello Windows".getBytes(StandardCharsets.UTF_8));
+        Files.write(
+            temp.resolve("test.txt"),
+            "Hello Windows".getBytes(StandardCharsets.UTF_8)
+        );
         MatcherAssert.assertThat(
             "must list files in directory",
             new Jaxec("cmd")
@@ -330,6 +336,7 @@ final class JaxecTest {
         MatcherAssert.assertThat(
             "must work just fine",
             new String(Files.readAllBytes(out), StandardCharsets.UTF_8),
+            // @checkstyle ProhibitLineSeparatorInStringsCheck (1 line)
             Matchers.equalTo("hello\n")
         );
     }
@@ -515,5 +522,4 @@ final class JaxecTest {
             logger.setLevel(original);
         }
     }
-
 }

--- a/src/test/java/com/yegor256/package-info.java
+++ b/src/test/java/com/yegor256/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Tests for the main class.
- *
  * @since 0.0.1
  */
 package com.yegor256;

--- a/src/test/java/fakes/FakeAppender.java
+++ b/src/test/java/fakes/FakeAppender.java
@@ -47,8 +47,8 @@ import org.apache.log4j.spi.LoggingEvent;
  * @since 1.0
  * @checkstyle ProtectedMethodInFinalClassCheck (100 lines)
  */
-@SuppressWarnings("PMD.TestClassWithoutTestCases")
 public final class FakeAppender extends AppenderSkeleton {
+
     /**
      * List of captured log messages.
      * Each message is stored as a string representation of the
@@ -104,7 +104,6 @@ public final class FakeAppender extends AppenderSkeleton {
 
     /**
      * Get the number of captured messages.
-     *
      * @return The count of logged messages
      */
     public int size() {
@@ -113,7 +112,6 @@ public final class FakeAppender extends AppenderSkeleton {
 
     /**
      * Check if any messages have been captured.
-     *
      * @return True if no messages have been logged,
      *  false otherwise
      */

--- a/src/test/java/fakes/package-info.java
+++ b/src/test/java/fakes/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Fake implementations for testing.
- *
  * @since 1.0
  */
 package fakes;


### PR DESCRIPTION
@yegor256, this PR upgrades all of the project'''s direct dependencies and Maven plugins to their latest stable versions, fixes the new Qulice 0.27.5 violations the upgrade exposed, and additionally resolves the long-standing Windows CI failure tracked in #83.

## Dependency / plugin upgrades

- ''com.jcabi:parent'' 0.69.6 → 0.73.1
- JUnit Jupiter (api/engine/params) 5.13.4 → 6.0.3
- JUnit Platform (engine/commons) 1.13.4 → 6.0.3
- ''pitest-maven'' 1.20.3 → 1.23.1
- ''qulice-maven-plugin'' 0.24.2 → 0.27.5

The remaining direct dependencies (''jcabi-log'', ''hamcrest'', ''reload4j'', ''revapi-*'', ''pitest-junit5-plugin'') were already at the latest stable releases.

## Fixes for the Qulice 0.27.5 upgrade

Qulice 0.27.5 introduced a number of stricter Checkstyle/PMD checks. I addressed the new violations rather than blanket-suppressing them:

- ''Result.java'' – removed trailing dots from ''@return'' Javadoc tags (''JavadocTagsDotCheck'').
- ''Jaxec.java'' – added per-constructor ''@checkstyle ConstructorsCodeFreeCheck'' suppression on the chained ''this(...)'' calls (the API surface is unchanged), and removed the now-redundant ''PMD.GodClass'' suppression flagged as unused.
- Various files – stripped empty lines before closing braces (''RegexpMultilineCheck'') and dropped the empty Javadoc lines before ''@since'' that are no longer allowed by ''JavadocEmptyLineBeforeTagCheck'' (''package-info.java'', ''FakeAppender.java'', ''JaxecTest.java'').
- ''FakeAppender.java'' – added the now-required empty line before the first member (''EmptyLineBeforeFirstMemberCheck'') and dropped the unused ''PMD.TestClassWithoutTestCases'' suppression.
- ''JaxecTest.java'' – inlined an unnecessary local variable in ''listDirectoryInWindows''; suppressed ''PMD.UnitTestContainsTooManyAsserts'' (multi-fact stdout/file assertions) and ''PMD.UnnecessaryLocalRule'' (the ''original'' log level we restore in ''finally''); suppressed a single ''ProhibitLineSeparatorInStringsCheck'' on a Unix-only test where the ''\n'' literal is intentional.

## CI

- **Drop Java 17 from the matrix.** Qulice 0.27.5 ships Java 21 bytecode (''class file version 65''), so Java 17 runners can no longer load the plugin. This matches what other yegor256 repos (''jhome'', ''jcabi-urn'') already do.
- **Resolve issue #83 – Windows build is broken.** PIT mutation coverage was failing on Windows because most of the test suite is OS-disabled there (no ''cat''/''head''/''tail''/''sh''/''mvn'' on the runner without WSL), so coverage dropped well below the 65% threshold. I moved the ''pitest-maven'' plugin into a ''pit'' profile that auto-activates only on the ''unix'' OS family, mirroring the pattern in jhome''s pom.xml. PIT still runs on Linux/macOS; Windows now runs Surefire + Qulice only.

## Validation

''mvn --batch-mode clean install -Pqulice'' passes locally on Linux with Java 21. CI is green on all 11 jobs of this PR (Linux/macOS/Windows × Java 21, plus actionlint, copyrights, markdown-lint, pdd, reuse, typos, xcop, yamllint).
