### PR TITLE
Upgrade GitHub Actions to latest stable versions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/up.yml
+++ b/.github/workflows/up.yml
@@ -17,7 +17,7 @@ jobs:
           git fetch --tags --force && \
           latest=$(git tag --sort=creatordate | tail -1) && \
           sed -E -i "s/<version>[^<]+/<version>${latest}/g" README.md
-      - uses: peter-evans/create-pull-request@v7
+      - uses: peter-evans/create-pull-request@v8
         with:
           sign-commits: true
           commit-message: 'new version in README'


### PR DESCRIPTION
@yegor256 this PR upgrades GitHub Actions to their latest stable versions. All Maven dependencies and plugins were already at their latest stable releases at the time of this change.

## Changes

- `actions/cache`: `v4` → `v5` (in `.github/workflows/codecov.yml` and `.github/workflows/mvn.yml`)
- `peter-evans/create-pull-request`: `v7` → `v8` (in `.github/workflows/up.yml`)

## Maven dependency audit

Verified via `mvn versions:display-dependency-updates versions:display-plugin-updates versions:display-parent-updates` — all already at latest stable:

- Parent: `com.jcabi:parent` 0.73.1 ✓
- `com.jcabi:jcabi-log` 0.24.3 ✓
- `org.hamcrest:hamcrest` 3.0 ✓
- `org.junit.jupiter:*` and `org.junit.platform:*` 6.0.3 ✓ (6.1.0-RC1 is a release candidate, not stable)
- `ch.qos.reload4j:reload4j` 1.2.26 ✓
- `org.revapi:revapi-maven-plugin` 0.15.1 ✓
- `org.revapi:revapi-java` 0.28.4 ✓
- `org.pitest:pitest-maven` 1.23.1 ✓
- `org.pitest:pitest-junit5-plugin` 1.2.3 ✓
- `com.qulice:qulice-maven-plugin` 0.27.6 ✓

## Verification

- Local: `mvn --errors --batch-mode clean install -Pqulice` passes (with `LANG=C.UTF-8`)
- CI: all 11 jobs green — `mvn` on `ubuntu-24.04`, `macos-15`, `windows-2022` plus `actionlint`, `codecov`-related lints, `copyrights`, `markdown-lint`, `pdd`, `reuse`, `typos`, `xcop`, `yamllint`

This effectively supersedes Renovate PRs #94 and #95 by bundling both action upgrades into a single review.