### PR TITLE
test: #83 add windows env variable test

### DIFF
--- a/src/test/java/com/yegor256/JaxecTest.java
+++ b/src/test/java/com/yegor256/JaxecTest.java
@@ -69,6 +69,19 @@ final class JaxecTest {
 
     @Test
     @EnabledOnOs(OS.WINDOWS)
+    void runsWithEnvironmentVariableInWindows() {
+        MatcherAssert.assertThat(
+            "passes env variable to the process on Windows",
+            new Jaxec("cmd", "/c", "echo", "%FOO%")
+                .withEnv("FOO", "hello, world")
+                .exec()
+                .stdout(),
+            Matchers.containsString("world")
+        );
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
     void simpleCommandInWindows() {
         MatcherAssert.assertThat(
             "must work just fine",


### PR DESCRIPTION
Issue #83 asks for more Windows-platform tests so PITest can mutate the `withEnv` path on both operating systems. The Linux side already had `runsWithEnvironmentVariable`, but no Windows counterpart existed.

Adds one JUnit method `runsWithEnvironmentVariableInWindows`, gated by `@EnabledOnOs(OS.WINDOWS)`, that runs `cmd /c echo %FOO%` with `FOO` set through `withEnv` and asserts the value reaches the spawned process.

Ran `mvn clean test-compile` and `LANG=C.utf8 LC_ALL=C.utf8 mvn test` locally on Linux: 31 tests run, 0 failures, 15 skipped (the Windows-only ones, including the new method, as expected on Linux).

Closes #83
